### PR TITLE
General optimisations

### DIFF
--- a/wle_pp/wle_pp/js/pp/cauldron/physics/physics_utils.js
+++ b/wle_pp/wle_pp/js/pp/cauldron/physics/physics_utils.js
@@ -36,20 +36,31 @@ PP.PhysicsUtils = {
                             objects = internalRaycastResult.objects;
                         }
 
-                        if (raycastSetup.myObjectsToIgnore.pp_hasEqual(objects[i], objectsEqualCallback)) {
+                        if (raycastSetup.myObjectsToIgnore.pp_hasEqual(objects[i]/*, objectsEqualCallback*/)) {
                             continue;
                         }
                     }
 
                     if (!distances) {
                         distances = internalRaycastResult.distances;
-                        locations = internalRaycastResult.locations;
-                        normals = internalRaycastResult.normals;
                     }
 
-                    const isHitInsideCollision = distances[i] === 0
-                        && (raycastSetup.myOrigin.vec3_distance(locations[i]) < 0.00001
-                            && Math.abs(raycastSetup.myDirection.vec3_angle(normals[i]) - 180) < 0.00001);
+                    let isHitInsideCollision = distances[i] === 0;
+                    if (isHitInsideCollision) {
+                        if (!locations) {
+                            locations = internalRaycastResult.locations;
+                        }
+
+                        isHitInsideCollision &&= raycastSetup.myOrigin.vec3_distance(locations[i]) < 0.00001;
+
+                        if (isHitInsideCollision) {
+                            if (!normals) {
+                                normals = internalRaycastResult.normals;
+                            }
+
+                            isHitInsideCollision &&= Math.abs(raycastSetup.myDirection.vec3_angle(normals[i]) - 180) < 0.00001;
+                        }
+                    }
 
                     if (!raycastSetup.myIgnoreHitsInsideCollision || !isHitInsideCollision) {
                         let hit = null;
@@ -66,6 +77,14 @@ PP.PhysicsUtils = {
 
                         if (!objects) {
                             objects = internalRaycastResult.objects;
+                        }
+
+                        if (!locations) {
+                            locations = internalRaycastResult.locations;
+                        }
+
+                        if (!normals) {
+                            normals = internalRaycastResult.normals;
                         }
 
                         hit.myPosition.vec3_copy(locations[i]);

--- a/wle_pp/wle_pp/js/pp/cauldron/physics/physics_utils.js
+++ b/wle_pp/wle_pp/js/pp/cauldron/physics/physics_utils.js
@@ -36,7 +36,7 @@ PP.PhysicsUtils = {
                             objects = internalRaycastResult.objects;
                         }
 
-                        if (raycastSetup.myObjectsToIgnore.pp_hasEqual(objects[i]/*, objectsEqualCallback*/)) {
+                        if (raycastSetup.myObjectsToIgnore.pp_hasEqual(objects[i], objectsEqualCallback)) {
                             continue;
                         }
                     }

--- a/wle_pp/wle_pp/js/pp/input/cauldron/tracked_hand_draw_skin.js
+++ b/wle_pp/wle_pp/js/pp/input/cauldron/tracked_hand_draw_skin.js
@@ -32,7 +32,7 @@ WL.registerComponent('pp-tracked-hand-draw-skin', {
         let skinJointIDs = this._myHandSkin.jointIds;
 
         for (let i = 0; i < skinJointIDs.length; i++) {
-            this._myJoints[i] = new WL.Object(skinJointIDs[i]);
+            this._myJoints[i] = WL.Object._wrapObject(skinJointIDs[i]);
         }
     }
 });

--- a/wle_pp/wle_pp/js/pp/plugin/extensions/array_extension.js
+++ b/wle_pp/wle_pp/js/pp/plugin/extensions/array_extension.js
@@ -208,28 +208,40 @@ Array.prototype.pp_findAllIndexes = function (callback) {
 
 Array.prototype.pp_findEqual = function (elementToFind, elementsEqualCallback = null) {
     if (elementsEqualCallback == null) {
-        return this.pp_find(element => element === elementToFind);
+        const index = this.indexOf(elementToFind);
+        return index < 0 ? undefined : this[index];
     }
     return this.pp_find(element => elementsEqualCallback(element, elementToFind));
 };
 
+function arrayFindAll(array, elementToFind, getIndex) {
+    // adapted from: https://stackoverflow.com/a/20798567
+    const matches = [];
+    let index = -1;
+    while ((index = array.indexOf(elementToFind, index + 1)) >= 0) {
+        matches.push(getIndex ? index : array[index]);
+    }
+
+    return matches;
+}
+
 Array.prototype.pp_findAllEqual = function (elementToFind, elementsEqualCallback = null) {
     if (elementsEqualCallback == null) {
-        return this.pp_findAll(element => element === elementToFind);
+        return arrayFindAll(this, elementToFind, false);
     }
     return this.pp_findAll(element => elementsEqualCallback(element, elementToFind));
 };
 
 Array.prototype.pp_findIndexEqual = function (elementToFind, elementsEqualCallback = null) {
     if (elementsEqualCallback == null) {
-        return this.findIndex(element => element === elementToFind);
+        return this.indexOf(elementToFind);
     }
     return this.findIndex(element => elementsEqualCallback(element, elementToFind));
 };
 
 Array.prototype.pp_findAllIndexesEqual = function (elementToFind, elementsEqualCallback = null) {
     if (elementsEqualCallback == null) {
-        return this.pp_findAllIndexes(element => element === elementToFind);
+        return arrayFindAll(this, elementToFind, true);
     }
     return this.pp_findAllIndexes(element => elementsEqualCallback(element, elementToFind));
 };
@@ -274,7 +286,12 @@ Array.prototype.pp_removeAll = function (callback) {
 
 Array.prototype.pp_removeEqual = function (elementToRemove, elementsEqualCallback = null) {
     if (elementsEqualCallback == null) {
-        return this.pp_remove(element => element === elementToRemove);
+        const index = this.indexOf(elementToRemove);
+        if (index >= 0) {
+            return this.splice(index, 1)[0];
+        } else {
+            return;
+        }
     }
     return this.pp_remove(element => elementsEqualCallback(element, elementToRemove));
 };

--- a/wle_pp/wle_pp/js/pp/plugin/extensions/scene_extension.js
+++ b/wle_pp/wle_pp/js/pp/plugin/extensions/scene_extension.js
@@ -24,7 +24,7 @@
 if (WL && WL.Scene) {
 
     WL.Scene.prototype.pp_getRoot = function () {
-        return new WL.Object(0);
+        return WL.Object._wrapObject(0);
     }
 
     WL.Scene.prototype.pp_getObjects = function () {


### PR DESCRIPTION
## raycast memory optimisations
The `raycast` physics utility uses too much memory, because the internal raycast getters (`objects`, `distances`, `locations` and `normals`) create a new copy of an array every time they are accessed, and the loop doesn't reuse the value of these getters.

To fix the memory usage, the result of these getters is now reused between loop iterations, and the getters are only called when needed (lazy caching).

The memory usage problem affects a certain project that we both have access to (the name ends with a 1). Here's the memory usage on that project. Before optimisation (the getters are using a large share of the total memory):

![mem-usage-no-optimisation](https://user-images.githubusercontent.com/15365765/218717342-7a8e211e-6c6b-4f7f-b857-c60c8aed84ca.png)

After reusing the getter results between iterations, without lazy getting (the `objects` getter usage improved, but `locations` and `normals` are still using too much memory):

![mem-usage-reuse-optimisation](https://user-images.githubusercontent.com/15365765/218717696-227d6a35-a7d3-414f-b7eb-7614147adc88.png)

Reusing between iterations, with lazy getting (`locations` and `normals` memory usage is now better too):

![mem-usage-lazy-reuse-optimisation](https://user-images.githubusercontent.com/15365765/218718935-9574e326-a3cd-4e66-9263-f0bd0e632577.png)

## Other optimisations
- Optimised all Array search functions when comparison function is not provided as an argument; the search functions will try to use indexOf instead of find, which is less memory-intensive, since you don't have to create a new lambda on each search - on our project, this reduces the memory usage of `pp_hasEqual` from 6.4% to 0.6%
- ~~`raycast` now uses no comparison function when calling `pp_hasEqual`. This might be unsafe for future versions of WLE, so let me know if you want me to remove the optimisation~~ removed for now, might be added in the future if the WLE devs decide to enforce object equality
- Prefer using `WL.Object._wrapObject` instead of `new WL.Object`, so that the same object is returned when passing the same objectId (so we can safely use the identity operator)